### PR TITLE
Bump Jinja2 from 2.9.6 to 2.10.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ click = "==6.7"
 itsdangerous = "==0.24"
 requests = ">=2.20.0"
 Flask = "==0.12.3"
-"Jinja2" = "==2.9.6"
+"Jinja2" = "==2.10.1"
 MarkupSafe = "==1.0"
 Werkzeug = "==0.12.1"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -62,11 +62,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:2231bace0dfd8d2bf1e5d7e41239c06c9e0ded46e70cc1094a0aa64b0afeb054",
-                "sha256:ddaa01a212cd6d641401cb01b605f4a4d9f37bfc93043d7f760ec70fb99ff9ff"
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b",
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013"
             ],
             "index": "pypi",
-            "version": "==2.9.6"
+            "version": "==2.10.1"
         },
         "markupsafe": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click==6.7
 Flask==0.12.3
 itsdangerous==0.24
-Jinja2==2.9.6
+Jinja2==2.10.1
 MarkupSafe==1.0
 requests>=2.20.0
 Werkzeug==0.12.1


### PR DESCRIPTION
The plan is to move it to master. It will be tested in dev and demo environments.
Once confirmed working correctly we create new release and change it in production.
Hope that clarifies the process
